### PR TITLE
Defensive fix: surface HTTP 4xx as a user error in kds-team.ex-http-extended

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -29,6 +29,13 @@ MANDATORY_IMAGE_PARS = []
 APP_VERSION = '0.0.1'
 
 
+class UserException(Exception):
+    """
+    Raised for failures the end user can fix themselves (e.g. a wrong URL or invalid credentials).
+    Surfaced by the entrypoint as a user error (exit code 1) instead of an application error (exit code 2).
+    """
+
+
 class Component(KBCEnvHandler):
 
     def __init__(self, debug=False):
@@ -94,7 +101,19 @@ class Component(KBCEnvHandler):
         additional_params['stream'] = True
 
         res = requests.get(path, **additional_params)
-        res.raise_for_status()
+        try:
+            res.raise_for_status()
+        except requests.exceptions.HTTPError as http_error:
+            # A 4xx means the request itself was rejected - the URL, the query parameters or the credentials
+            # in the configuration are wrong. Re-raise so the job still fails, but as a user error the user
+            # can act on, instead of an opaque application error.
+            if 400 <= res.status_code < 500:
+                raise UserException(
+                    F'The request to "{path}" failed with HTTP {res.status_code} ({res.reason}). '
+                    'Please check that the URL is correct and reachable, that the requested resource exists, '
+                    'and that any credentials, headers or additional request parameters in the configuration '
+                    'are valid.') from http_error
+            raise
 
         res_file_path = os.path.join(self.data_path, 'out', 'files', params[KEY_RES_FILE_NAME])
         with open(res_file_path, 'wb+') as out:
@@ -179,6 +198,9 @@ if __name__ == "__main__":
     try:
         comp = Component()
         comp.run()
+    except UserException as exc:
+        logging.error(exc)
+        exit(1)
     except Exception as exc:
         logging.exception(exc)
         exit(2)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -6,9 +6,38 @@ Created on 12. 11. 2018
 import unittest
 import mock
 import os
+import json
+import tempfile
+import requests
 from freezegun import freeze_time
 
-from component import Component
+from component import Component, UserException
+
+
+def _build_data_dir(base_dir, parameters):
+    """
+    Creates a minimal KBC data directory with the given parameters and returns its path.
+    """
+    os.makedirs(os.path.join(base_dir, 'out', 'files'))
+    with open(os.path.join(base_dir, 'config.json'), 'w') as cfg:
+        json.dump({'parameters': parameters, 'image_parameters': {}}, cfg)
+    return base_dir
+
+
+def _mock_response(status_code, reason, content=b''):
+    """
+    Builds a requests.Response-like mock that mimics raise_for_status() for the given status code.
+    """
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.reason = reason
+    response.iter_content.return_value = [content] if content else []
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            F'{status_code} Client Error: {reason} for url: https://example.com/file.csv', response=response)
+    else:
+        response.raise_for_status.return_value = None
+    return response
 
 
 class TestComponent(unittest.TestCase):
@@ -21,6 +50,57 @@ class TestComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             comp = Component()
             comp.run()
+
+
+class TestHttpErrorHandling(unittest.TestCase):
+    """
+    Regression tests for the defensive handling of failed HTTP responses.
+    """
+
+    PARAMETERS = {'path': 'https://example.com/file.csv', 'file_name': 'file.csv'}
+
+    def _run_with_response(self, response):
+        """
+        Runs the component against a mocked HTTP response and returns the bytes written to the output file
+        (None when no output file was produced).
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_dir = _build_data_dir(tmp_dir, self.PARAMETERS)
+            with mock.patch.dict(os.environ, {'KBC_DATADIR': data_dir}):
+                with mock.patch('component.requests.get', return_value=response):
+                    comp = Component()
+                    comp.run()
+            res_file_path = os.path.join(data_dir, 'out', 'files', self.PARAMETERS['file_name'])
+            if not os.path.isfile(res_file_path):
+                return None
+            with open(res_file_path, 'rb') as res_file:
+                return res_file.read()
+
+    def test_client_error_raises_user_exception(self):
+        """A 4xx is the user's problem (wrong URL / credentials) - it must fail as a user error."""
+        with self.assertRaises(UserException) as ctx:
+            self._run_with_response(_mock_response(404, 'Not Found'))
+
+        message = str(ctx.exception)
+        self.assertIn('404', message)
+        self.assertIn('Not Found', message)
+        self.assertIn(self.PARAMETERS['path'], message)
+
+    def test_client_error_chains_original_http_error(self):
+        """The original requests exception is kept as the cause, so nothing is lost from the log."""
+        with self.assertRaises(UserException) as ctx:
+            self._run_with_response(_mock_response(401, 'Unauthorized'))
+
+        self.assertIsInstance(ctx.exception.__cause__, requests.exceptions.HTTPError)
+
+    def test_server_error_still_raises_http_error(self):
+        """Non-4xx failures must keep behaving exactly as before - raw HTTPError, application error."""
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self._run_with_response(_mock_response(503, 'Service Unavailable'))
+
+    def test_successful_response_is_unaffected(self):
+        """The happy path must be untouched - the response body is still written to the output file."""
+        self.assertEqual(b'a,b\n1,2\n', self._run_with_response(_mock_response(200, 'OK', content=b'a,b\n1,2\n')))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds defensive handling for an unhandled `requests.exceptions.HTTPError` observed in production. No change to the component's behaviour on inputs that already worked.

## Root cause
`requests.exceptions.HTTPError` at `src/component.py:97` (`res.raise_for_status()`) — the user-configured source URL (the mandatory `path` parameter) returned **HTTP 404**, so the exception propagated to the entrypoint's generic `except Exception` handler and the job died with **exit code 2 (application error)**. That pages the dev team even though the cause is a wrong or no-longer-existing URL that only the user can fix. Classified as **user-actionable (exit 2 → exit 1)**; 1 occurrence in the alert window (the same shape recurs whenever a configured URL 404s / 401s / 403s).

## Fix
A new, narrow `try/except requests.exceptions.HTTPError` around `res.raise_for_status()`:

- **4xx** → re-raised as a new `UserException` whose message names the status, the reason and the URL, and tells the user what to check (URL correctness/reachability, resource existence, credentials/headers/request params). The original `HTTPError` is chained via `from`, so nothing is lost from the log.
- **Anything else (5xx, non-HTTP errors)** → bare `raise`, i.e. byte-for-byte the previous behaviour.

The entrypoint gains one additional `except UserException` branch that logs the message and `exit(1)`; the existing `except Exception` → `exit(2)` branch is unchanged.

## Behaviour impact: none — defensive-only
- Happy path unchanged. On a 2xx, `raise_for_status()` still no-ops and the streaming file-write plus manifest handling below it are untouched. No outputs, transforms, schema, or config semantics touched.
- The job **still fails** on a genuine failure. A 404 does not become an empty success — it becomes a clear exit-1 user error instead of an opaque exit-2 internal error. Nothing is swallowed.
- Non-4xx failures keep their exact previous behaviour (raw `HTTPError`, exit 2).
- The pre-existing test is untouched (no assertion modified or deleted); the test file is otherwise purely additive.

## Evidence
Datadog: [monitor 97152903 — `kds-team.ex-http-extended` ended with internal error](https://app.datadoghq.eu/monitors/97152903?group=%40job.componentId%3Akds-team.ex-http-extended)

## Tests
Run exactly as CI does, in the built image:

- `flake8 . --config=flake8.cfg` — clean.
- `python -m unittest discover` — **5 passed** (1 pre-existing, unchanged + 4 new).

New regression tests (`TestHttpErrorHandling`) cover all four branches with a mocked response:

| Case | Assertion |
|---|---|
| 404 | `UserException` raised, message contains status, reason and URL |
| 401 | `UserException.__cause__` is the original `requests.exceptions.HTTPError` |
| 503 | raw `requests.exceptions.HTTPError` still propagates (unchanged) |
| 200 | response body still written to the output file (happy path intact) |

End-to-end exit codes were also verified against the entrypoint in the built image: **404 → exit 1**, **503 → exit 2**.